### PR TITLE
Improve first run experience. Add README

### DIFF
--- a/README
+++ b/README
@@ -1,0 +1,5 @@
+# ./README
+npm install
+npm install -g babel
+sleep 2 && open http://localhost:3500 &
+npm run start

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "uglify-js": "~2.4.13"
   },
   "scripts": {
-    "run": "babel-node server.js",
+    "start": "babel-node server.js",
     "build": "NODE_ENV=production browserify ./ | uglifyjs -cm 2>/dev/null > ./assets/bundle.js",
     "start-prod": "NODE_ENV=production babel-node server.js",
     "clean": "rm -f ./assets/bundle.js"


### PR DESCRIPTION
It looks like babel is marked as a devDependency. Any idea why `npm install -g babel` is required?
